### PR TITLE
feat: top pagination in list

### DIFF
--- a/src/components/List.vue
+++ b/src/components/List.vue
@@ -6,6 +6,12 @@
                 <input class="input w-full mb-4" name="search" :placeholder="t('generic.search')" @keyup="search">
             </slot>
 
+            <slot name="pagination">
+                <div class="flex justify-center" :class="list?.results.length ? ['my-4'] : []" v-if="list?.pagination">
+                    <paginator :pagination-data="list?.pagination" :set-page="setPage" />
+                </div>
+            </slot>
+
             <slot name="results" :results="list?.results" :meta="list?.meta" :update="update">
                 <table :key="list?.results" class="w-full block xl:table">
                     <tbody>


### PR DESCRIPTION
Hey, haven't really found any workflow or rules for pull requests, so I hope this will be sufficient.

#### Description
Since the 2b220311c31df832755651b9b2d9aeb28dfa1a61 introduced 100 items per-page, I think it would be appropriate to also have a top-pagination, because scrolling 100 items down just to press 1 button might get boring quickly.

#### Feature
Adding pagination to the top of list, instead of being just at the bottom.
Correct bottom padding is also included.

I tested this on local environment and no issues should arise from such a small change.