### PR TITLE
fix: mobile responsiveness for "My Servers" page

### DIFF
--- a/src/components/Paginator.vue
+++ b/src/components/Paginator.vue
@@ -1,17 +1,17 @@
 <template>
     <ul v-if="paginationData.totalPages > 1">
         <li :class="firstPage ? ['disabled'] : []">
-            <button @click="setPage(currentPage - 1)">
+            <button class="p-4 md:py-3" @click="setPage(currentPage - 1)">
                 ‹
             </button>
         </li>
         <li v-for="page of pageElements" :class="currentPage === page && ['active'] || page === '...' && ['disabled'] || []">
-            <button @click="setPage(page)">
+            <button class="p-4 md:py-3" @click="setPage(page)">
                 {{ page }}
             </button>
         </li>
         <li :class="lastPage ? ['disabled'] : []">
-            <button @click="setPage(currentPage + 1)">
+            <button class="p-4 md:py-3" @click="setPage(currentPage + 1)">
                 ›
             </button>
         </li>
@@ -33,7 +33,6 @@
         background: #1D1C39;
         color: rgba(255,255,255,.5) !important;
         border: none !important;
-        padding: 1rem 1.4rem;
         box-shadow: none !important;
     }
 

--- a/src/views/GenericLayout.vue
+++ b/src/views/GenericLayout.vue
@@ -8,7 +8,7 @@
         <div class="flex-grow" :class="preference === 1 ? ['flex', 'flex-col', 'items-center'] : ['pl-0', 'md:pl-64', 'mt-12 md:mt-0']">
             <socket-error-notice />
 
-            <div class="m-8" :class="preference === 1 ? ['container'] : []">
+            <div class="mx-4 mt-8 md:mx-8" :class="preference === 1 ? ['container'] : []">
                 <div class="flex flex-col md:flex-row justify-between items-center mb-8">
                     <div class="flex">
                         <div class="w-14 h-14 md:w-20 md:h-20 mr-3 flex items-center justify-center header-icon shrink-0">

--- a/src/views/Index.vue
+++ b/src/views/Index.vue
@@ -5,7 +5,7 @@
                 <input class="input w-full mb-8" name="search" :placeholder="t('generic.search')" @keyup="list.search">
             </div>
 
-            <div class="flex flex-wrap flex-col lg:flex-row gap-y-6" v-if="list.results.length > 0">
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-6" v-if="list.results.length > 0">
                 <server-card v-for="(result, idx) of list.results" :key="idx" :server="result" />
             </div>
             <div v-else>
@@ -13,7 +13,7 @@
                 <t path="generic.no_items" />
             </div>
 
-            <div class="flex justify-center">
+            <div class="flex justify-center mt-8">
                 <paginator :pagination-data="list.pagination" :set-page="list.setPage" />
             </div>
         </template>

--- a/src/views/ServerCard.vue
+++ b/src/views/ServerCard.vue
@@ -1,8 +1,8 @@
 <template>
-    <div class="w-full lg:w-1/2 lg:even:pl-3 lg:odd:pr-3">
+    <div class="w-full lg:even:pl-3 lg:odd:pr-3">
         <div class="server flex flex-col text-center overflow-hidden whitespace-nowrap" :style="`--thumbnail:url('${server?.egg?.thumbnail || minecraft}');`">
             <div class="gradient" />
-            <div class="flex items-center bg-primary-900 bg-opacity-25 px-8 py-4">
+            <div class="flex items-center bg-primary-900 bg-opacity-25 px-4 md:px-8 py-4">
                 <div class="self-start mt-1 mr-2">
                     <span v-if="!server || stats.status === -2" class="text-accent-500">
                         <fa :icon="['fas', 'spinner']" spin fixed-width />
@@ -20,9 +20,9 @@
                     </skeleton>
                     <p class="text-white/75">
                         <skeleton :content="16">
-                            <span v-clipboard>{{ server.primaryAllocation().displayName() }}</span>
+                            <span class="tracking-wide" v-clipboard>{{ server.primaryAllocation().displayName() }}</span>
 
-                            <span class="text-white/50">
+                            <span class="text-white/50 block md:inline text-sm leading-none tracking-tight">
                                 <t :path="['generic.server.on_node', { node: server.node.name }]" />
                             </span>
                         </skeleton>
@@ -31,7 +31,7 @@
 
                 <button
                     v-tippy="'generic.server.go_to_console'"
-                    class="border border-primary-50 px-2 rounded text-primary-0 hover:text-white mr-4"
+                    class="border border-primary-50 px-2 rounded text-primary-0 hover:text-white mr-4 hidden md:block"
                     @click="server?.openConsolePopup()"
                 >
                     <fa :icon="['fas', 'external-link-square-alt']" fixed-width />
@@ -40,7 +40,7 @@
                     <router-link :to="{name: 'server.system.index', params: { server: server?.uuidShort }}">
                         <button
                             v-tippy="'generic.server.manage'"
-                            class="border border-primary-50 px-2 rounded text-primary-0 hover:text-white"
+                            class="border border-primary-50 px-2 rounded text-primary-0 hover:text-white hidden md:block"
                         >
                             <fa :icon="['fas', 'wrench']" fixed-width />
                         </button>
@@ -48,30 +48,30 @@
                 </skeleton>
             </div>
 
-            <div class="flex flex-wrap justify-between align-start px-8 py-4">
-                <p v-tippy="'generic.server.cpu'" class="text-white">
+            <div class="grid grid-cols-2 xl:grid-cols-4 px-4 py-2 md:px-8 md:py-4">
+                <p v-tippy="'generic.server.cpu'" class="block md:flex 2xl:block flex-col items-center text-white text-sm xl:text-normal tracking-tight">
                     <skeleton :content="8">
-                        <fa class="text-white/50 mr-1" :icon="['fas', 'tachometer-alt']" size="sm" fixed-width />
+                        <fa class="text-white/50 mr-1 inline md:block 2xl:inline" :icon="['fas', 'tachometer-alt']" size="sm" fixed-width />
                         {{ stats.proc?.cpu?.total?.toFixed(2) ?? '--' }} %
                     </skeleton>
                 </p>
-                <p v-tippy="'generic.server.memory'" class="text-white">
+                <p v-tippy="'generic.server.memory'" class="block md:flex 2xl:block flex-col items-center text-white text-sm xl:text-normal tracking-tight">
                     <skeleton :content="8">
-                        <fa class="text-white/50 mr-1" :icon="['fas', 'memory']" size="sm" fixed-width />
+                        <fa class="text-white/50 mr-1 inline md:block 2xl:inline" :icon="['fas', 'memory']" size="sm" fixed-width />
 
                         {{ memoryUsage }} / {{ memoryMax }}
                     </skeleton>
                 </p>
-                <p v-tippy="'generic.server.disk'" class="text-white">
+                <p v-tippy="'generic.server.disk'" class="block md:flex 2xl:block flex-col items-center text-white text-sm xl:text-normal tracking-tight">
                     <skeleton :content="8">
-                        <fa class="text-white/50 mr-1" :icon="['fas', 'hdd']" size="sm" fixed-width />
+                        <fa class="text-white/50 mr-1 inline md:block 2xl:inline" :icon="['fas', 'hdd']" size="sm" fixed-width />
 
                         {{ diskUsage }} / {{ diskMax }}
                     </skeleton>
                 </p>
-                <p v-tippy="'generic.server.players'" class="text-white">
+                <p v-tippy="'generic.server.players'" class="block md:flex 2xl:block flex-col items-center text-white text-sm xl:text-normal tracking-tight">
                     <skeleton :content="8">
-                        <fa class="text-white/50 mr-1" :icon="['fas', 'user']" size="sm" fixed-width />
+                        <fa class="text-white/50 mr-1 inline md:block 2xl:inline" :icon="['fas', 'user']" size="sm" fixed-width />
                         {{ stats.query?.players?.length ?? '--' }} / {{ stats.query?.maxplayers ?? '--' }}
                     </skeleton>
                 </p>


### PR DESCRIPTION
Made the "My Servers" page responsive for smaller screens.

Tested with both navbars & tested with iPhone / Laptop / 1080p Desktop screens - screenshots below of each

Desktop:
![](https://i.lunaversity.dev/firefox_SxFpbBl8VP.png)

Laptop:
![](https://i.lunaversity.dev/yrTGBVuW8C.png)

Phone:
![](https://i.lunaversity.dev/firefox_jON6HfGNLh.png)

Small note: I made the icons for medium screens (e.g. laptops & tablets) go to the top of the resources because they would overlap when side to side, but only on those screens.

Edit note: I also tried to balance the size of the pagination buttons better - when they were super large it would cause the page to overflow - they should be good now.