### PR TITLE
fix: password fields should not display values in plain text

### DIFF
--- a/src/views/account/Index.vue
+++ b/src/views/account/Index.vue
@@ -35,7 +35,7 @@
                     <v-input type="hidden" name="action" value="email" />
 
                     <v-input label="components.form.fields.new_email" name="email" :value="user.email" rule="required|email" />
-                    <v-input name="current_password" rule="required" />
+                    <v-input type="password" name="current_password" rule="required" />
 
                     <div class="text-right">
                         <v-submit color="primary" label="client.account.update_email" />
@@ -49,10 +49,10 @@
                 <v-form service-id="account@update" on-success="client.account.updated_password">
                     <v-input type="hidden" name="action" value="password" />
 
-                    <v-input name="current_password" rule="required" />
-                    <v-input name="new_password" footer="client.account.password_requirements" rule="required" />
+                    <v-input type="password" name="current_password" rule="required" />
+                    <v-input type="password" name="new_password" footer="client.account.password_requirements" rule="required" />
 
-                    <v-input name="new_password_confirmation" rule="required" />
+                    <v-input type="password" name="new_password_confirmation" rule="required" />
 
                     <div class="text-right">
                         <v-submit color="primary" label="client.account.update_password" />


### PR DESCRIPTION
See #134 for details, basically use `type="password"` for password inputs on the Account Settings page. I expect these fields to be protected and I think this is reasonable.

Fixes: #134 

Before:
![image](https://user-images.githubusercontent.com/34663790/153981026-ff593780-0a73-4fe5-9dc9-22a26167761d.png)

After:
![image](https://user-images.githubusercontent.com/34663790/153981061-e5c5cb29-3f95-49d0-b719-dc4a74702135.png)
