### PR TITLE
refactor: Indicate user "container" instead of "root" for console view.

### DIFF
--- a/src/views/server/Console.vue
+++ b/src/views/server/Console.vue
@@ -3,7 +3,7 @@
         <div ref="terminalElement" />
         <div class="flex terminal-input">
             <div class="text-gray-300 terminal-prompt">
-                root:~/<span class="text-accent-500">$</span>
+                container:~/<span class="text-accent-500">$</span>
             </div>
             <v-input
                 class="flex-grow"


### PR DESCRIPTION
### Introduction
Correction to the user utilized for the console view from `root` changed to `container`.

### Relevant Issues
Incorrect user ("root") mentioned for console input. #137 

### Changes
**UI Change**
- views/servers/Console: Indicate user as `container` instead of `root` (which is falsified). 

### Backwards compatibility
Backward Compatible.