### PR TITLE
refactor: decreased padding & added group hovering

### DIFF
--- a/src/components/List.vue
+++ b/src/components/List.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="w-full block overflow-x-auto">
+    <div class="w-full block">
         <slot name="layout" :results="list?.results" :pagination="list?.pagination" :search="search" :set-page="setPage">
             <slot v-if="searchable" name="search" :submit="search">
                 <div class="flex mb-4">
@@ -45,10 +45,10 @@
                         <template v-else>
                             <slot name="items-before" :update="update" />
 
-                            <tr v-for="(result, idx) in list?.results" :key="idx" class="bg-primary-500 border-b border-primary-400 block xl:table-row xl:border-none last:border-none" @click="onCheckboxRowClick($event, result)">
+                            <tr v-for="(result, idx) in list?.results" :key="idx" class="bg-primary-500 border-b border-primary-400 block xl:table-row xl:border-none last:border-none group hover:opacity-80 hover:text-white" @click="onCheckboxRowClick($event, result)">
                                 <slot name="fields-before" :result="result" :update="update" />
 
-                                <td class="px-6 pt-3 xl:py-6 text-center td-min" v-if="checkbox">
+                                <td class="px-6 pt-3 xl:py-4 text-center td-min" v-if="checkbox">
                                     <div class="flex items-center">
                                         <skeleton :content="2">
                                             <input class="input w-auto" type="checkbox" :ref="elem => registerCheckboxItem(elem, result)" @click="onCheckboxClick($el)">
@@ -76,7 +76,7 @@
                                     </div>
                                 </td>
 
-                                <td v-for="(field, fieldIdx) in fields" :key="fieldIdx" class="p-6 text-left hidden xl:table-cell" :style="field.style">
+                                <td v-for="(field, fieldIdx) in fields" :key="fieldIdx" class="p-4 text-left hidden xl:table-cell" :style="field.style">
                                     <skeleton :content="field.skeleton ?? field.key.length">
                                         <slot :name="`field-${field.key}`" :result="result" :update="update">
                                             <list-result :field="field" :value="result ? field.key.split('.').reduce((previous, current) => previous[current], result) : null ?? field.default" />

--- a/src/views/server/files/Index.vue
+++ b/src/views/server/files/Index.vue
@@ -103,12 +103,12 @@
 
                 <template #field-name="{ result }">
                     <template v-if="result.isDirectory">
-                        <v-button class="text-white text-opacity-50 hover:text-opacity-80" @click="navigateDirectory(result.name)">
+                        <v-button class="text-white text-opacity-50 group-hover:text-opacity-100" @click="navigateDirectory(result.name)">
                             {{ result.name }}
                         </v-button>
                     </template>
                     <template v-else>
-                        <v-button :to="{name: 'server.management.files.edit', hash: `#${path}${path.endsWith('/') ? '' : '/'}${result.name}`}" v-if="result.isReadable" permission="file.read" class="text-white text-opacity-50 hover:text-opacity-80">
+                        <v-button :to="{name: 'server.management.files.edit', hash: `#${path}${path.endsWith('/') ? '' : '/'}${result.name}`}" v-if="result.isReadable" permission="file.read" class="text-white text-opacity-50 group-hover:text-opacity-100">
                             {{ result.name }}
                         </v-button>
                         <template v-else>
@@ -130,7 +130,7 @@
                 </template>
 
                 <template #fields-after="{ result }">
-                    <td class="p-6 w-[10%]">
+                    <td class="p-4 w-[10%]">
                         <skeleton :content="4">
                             <file-actions-dropdown :path="path" :file="result" />
                         </skeleton>


### PR DESCRIPTION
Very minor but much needed touchups to the file manager.

Decreased padding between items so they're closer together
Added group hovering to help show what the mouse is hovering over since the items are a bit closer together now
The scrollbar on the bottom is gone, the file manager should be completely responsive so it's not needed

Screenshots below for comparison.

Old:
![](https://i.lunaversity.dev/firefox_bwNGeyoAum.png)

New:
![](https://i.lunaversity.dev/firefox_BlYujIeycI.png)