### PR TITLE
refactor: better design for alerts on small screens

### DIFF
--- a/src/assets/css/wisp.scss
+++ b/src/assets/css/wisp.scss
@@ -103,8 +103,6 @@ button {
 
   // TODO: Translate @media to tw using sm:* - but should we use bootstrap's breakpoints or move over to tailwinds??
   @media screen and (max-width: 576px) {
-    @apply flex-col;
-
     // TODO: Programmatically apply class (with important if its actually needed?)
     &:not(.alert-dismissible) > div {
       padding: 1rem !important;


### PR DESCRIPTION
Alert icons are now level with the message, as opposed to the icon container taking up unnecessary whitespace.
Closes #163 

Old:
<img width="369" alt="Screen Shot 2022-02-15 at 4 40 09 PM" src="https://user-images.githubusercontent.com/34663790/154155078-473e16fa-dc45-4790-ba93-3ca58e00546d.png">

New:
![image](https://user-images.githubusercontent.com/34663790/154155230-a6baeb3e-e9d7-46f0-88df-336f4fc3fbfd.png)
