### PR TITLE
fix: Reflect updates made to server details via administrative page.

### DIFF
--- a/src/api/services/admin/servers.ts
+++ b/src/api/services/admin/servers.ts
@@ -86,10 +86,7 @@ class ServersService {
     }
 
     updateDetails(data: UpdateDetailsRequest): Promise<Server> {
-        return RequestService.put('/servers/:server/details', {
-            ...data,
-            description: data.description.length > 0 ? data.description : "null"
-        })
+        return RequestService.put('/servers/:server/details', data)
             .then(Parser.parse)
             .then(server => {
                 dispatch('models/refresh', 'server');

--- a/src/api/services/admin/servers.ts
+++ b/src/api/services/admin/servers.ts
@@ -86,10 +86,7 @@ class ServersService {
     }
 
     updateDetails(data: UpdateDetailsRequest): Promise<Server> {
-        return RequestService.put('/servers/:server/details', {
-            ...data,
-            owner_id: 1,
-        })
+        return RequestService.put('/servers/:server/details', data)
             .then(Parser.parse)
             .then(RequestService.updateModelBinding);
     }

--- a/src/api/services/admin/servers.ts
+++ b/src/api/services/admin/servers.ts
@@ -91,7 +91,11 @@ class ServersService {
             description: data.description.length > 0 ? data.description : "null"
         })
             .then(Parser.parse)
-            .then(RequestService.updateModelBinding);
+            .then(server => {
+                dispatch('models/refresh', 'server');
+
+                return server;
+            });
     }
 
     updateBuild(data: UpdateBuildRequest): Promise<Server> {

--- a/src/api/services/admin/servers.ts
+++ b/src/api/services/admin/servers.ts
@@ -86,7 +86,10 @@ class ServersService {
     }
 
     updateDetails(data: UpdateDetailsRequest): Promise<Server> {
-        return RequestService.put('/servers/:server/details', data)
+        return RequestService.put('/servers/:server/details', {
+            ...data,
+            description: data.description.length > 0 ? data.description : "null"
+        })
             .then(Parser.parse)
             .then(RequestService.updateModelBinding);
     }


### PR DESCRIPTION
### Introduction
Aims to fix the issues that were associated with server details not properly propagating after it was changed via the administrative panel resulting in a multitude of internal errors which are addressed.

### Relevant Issues
Update does not propagate for Server Details. #143 [High Priority Bug]

### Changes
**API Services**
- admin/servers: 
  - Remove `owner_id` which was statically placed earlier on in the request body data section to ensure that the actual ID is utilized for functionality.
  - Forcefully check if the description has a length greater than zero, if so pass the user input as `description` from data otherwise use `"null"` in order to compensate for the backend API rejecting empty string fields.
  - Usage of refresh model dispatch over update since there are dropdown fields that wont update over model update dispatch. 

### Backwards Compatibility
Backwards Compatible since changes only reflect for the API services than the API itself, moreover change is made over the Request than the Details view.

### Tests
![Peek 2022-02-16 05-08](https://user-images.githubusercontent.com/24799477/154185052-6deb955b-062b-4d58-915e-da7661c6cf9e.gif)
