### PR TITLE
feat: Alphabetical sorting for nodes list on administrative page.

### DIFF
--- a/src/components/List.vue
+++ b/src/components/List.vue
@@ -137,6 +137,9 @@ export default defineComponent({
         checkbox: {
             type: Boolean,
         },
+        filter: {
+            type: String
+        },
         searchable: {
             type: Boolean,
         },
@@ -186,6 +189,12 @@ export default defineComponent({
         };
         const getAttribute = (key: string) => state.lists.data[serviceId]?.[key];
 
+        const filterList = (res: ListResponse) => {
+            if (props.filter == "alphabetical-nodes") res.data.sort((a: any, b: any) => a.name.localeCompare(b.name));
+
+            return res.data;
+        }
+
         const update = async () => {
             Logger.debug('List', `Updating list contents from ${props.serviceId}...`);
 
@@ -209,7 +218,7 @@ export default defineComponent({
             } else {
                 useService<ListResponse>(props.serviceId, true, paginatableRequest, props.data)
                     .then(res => {
-                        setAttribute('results', res.data);
+                        setAttribute('results', filterList(res));
                         setAttribute('meta', res.meta);
 
                         if (res.meta?.pagination) setAttribute('pagination', res.meta.pagination);

--- a/src/views/admin/nodes/Index.vue
+++ b/src/views/admin/nodes/Index.vue
@@ -1,5 +1,5 @@
 <template>
-    <list service-id="nodes@getAll" :fields="listFields" searchable>
+    <list service-id="nodes@getAll" :fields="listFields" filter="alphabetical-nodes" searchable> 
         <template #headers-before>
             <th />
         </template>


### PR DESCRIPTION
### Introduction
Aims to introduce alphabetical sorting for the nodes listing on the administrative page.

### Relevant Issues
Node list isn't sorted alphabetically #160 [Low Priority Enchancement]

### Changes
**UI Change**:
- components/List:
  - Include a `filter` prop to specify what kind of filtering is required, this is an optional prop and the lack of it wont affect functionality.
  - `filterList` function to sort through the list response data as per what is specified with the prop.
  **Note:** Filter for a view can be conducted in such a manner without disrupting operations down the flow of execution by intercepting it once the response has been received, however multiple "filters" would have to be defined since each response has its own data difference, additionally this may not be feasible for a dynamic integration of all results for future cases. (I am open for suggestions and learning more. 😄 )
- admin/nodes: Include the `filter` prop with "alphabetical-nodes" sorting.

### Backwards Compatibility
Backwards Compatible since even though the List component has a filter applied anything that does not satisfy it would get processed through without any issues.

### Tests
![Screenshot from 2022-02-16 09-05-33](https://user-images.githubusercontent.com/24799477/154206180-b4897478-a646-46b4-be54-e1df4b84cd90.png)
