### PR TITLE
feat: Implement Swap Tooltip.

### DIFF
--- a/src/locales/en/generic.json
+++ b/src/locales/en/generic.json
@@ -79,6 +79,7 @@
     "name": "Name",
     "cpu": "CPU",
     "memory": "Memory",
+    "swap": "Swap",
     "disk": "Disk",
     "node": "Node",
     "players": "Players",

--- a/src/views/admin/servers/manage/About.vue
+++ b/src/views/admin/servers/manage/About.vue
@@ -74,7 +74,7 @@
                     </td>
                     <td class="p-4">
                         <skeleton :content="12">
-                            <code>{{ server.limits.memory }} MB</code> / <code v-tippy="`Swap`">{{ server.limits.swap }} MB</code>
+                            <code>{{ server.limits.memory }} MB</code> / <code v-tippy="'generic.server.swap'">{{ server.limits.swap }} MB</code>
                         </skeleton>
                     </td>
                 </tr>

--- a/src/views/admin/servers/manage/About.vue
+++ b/src/views/admin/servers/manage/About.vue
@@ -74,7 +74,7 @@
                     </td>
                     <td class="p-4">
                         <skeleton :content="12">
-                            <code>{{ server.limits.memory }} MB</code> / <code>{{ server.limits.swap }} MB</code>
+                            <code>{{ server.limits.memory }} MB</code> / <code v-tippy="`Swap`">{{ server.limits.swap }} MB</code>
                         </skeleton>
                     </td>
                 </tr>


### PR DESCRIPTION
### Introduction
Aims to introduce missing swap tooltip for Servers About section on administrative page.

### Relevant Issues
Swap tooltip #165 [Low Priority Missing]

### Changes
**UI Change**:
- admin/servers/manage/About:
  - Include `v-tippy` prop directly injected with content of "Swap".

### Backwards Compatibility
Backwards Compatible.

### Tests
![Peek 2022-02-16 09-35](https://user-images.githubusercontent.com/24799477/154209885-9a47f81e-80d4-4b17-80a6-b77f20873c85.gif)
