### PR TITLE
Date component and format license expiry date

### DIFF
--- a/src/components/Date.vue
+++ b/src/components/Date.vue
@@ -11,7 +11,7 @@ import { formatDate, formatDateAbsolute } from '~/core/lang';
 export default defineComponent({
     props: {
         timestamp: {
-            type: String, Number,
+            type: String,
             required: true
         }
     },

--- a/src/components/Date.vue
+++ b/src/components/Date.vue
@@ -1,0 +1,30 @@
+<template>
+    <span v-tippy="formattedValue[1]" class="w-auto">
+        {{ formattedValue[0] }}
+    </span>
+</template>
+
+<script lang="ts">
+import { defineComponent, computed } from 'vue';
+import { formatDate, formatDateAbsolute } from '~/core/lang';
+
+export default defineComponent({
+    props: {
+        timestamp: {
+            type: String, Number,
+            required: true
+        }
+    },
+
+    setup(props) {
+        return {
+            formattedValue: computed(() => {
+                return [
+                    formatDate(props.timestamp, 'L LT'),
+                    formatDateAbsolute(props.timestamp as string, 'LLLL')
+                ];
+            }),
+        };
+    }
+});
+</script>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -6,6 +6,7 @@ export { default as Button } from './Button.vue';
 export { default as Can } from './Can.vue';
 export { default as Chart } from './Chart.vue';
 export { default as Container } from './Container.vue';
+export { default as Date } from './Date.vue';
 export { default as Footer } from './Footer.vue';
 export { default as List } from './List.vue';
 export { default as Modal } from './Modal.vue';

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,7 @@ import {
     Button,
     Chart,
     Container,
+    Date,
     Footer,
     List,
     TranslatedMessage,
@@ -52,6 +53,7 @@ app
     .component('chart', Chart)
     .component('can', Can)
     .component('container', Container)
+    .component('date', Date)
     .component('list', List)
     .component('modal', Modal)
     .component('paginator', Paginator)

--- a/src/views/admin/LicenseInfo.vue
+++ b/src/views/admin/LicenseInfo.vue
@@ -47,9 +47,8 @@
                         </td>
                         <td class="p-4">
                             <skeleton :content="16">
-                                <t v-if="!license?.expiresAt" path="generic.never" />
-
-                                <date v-else :timestamp="license?.expiresAt" />
+                                <date v-if="license?.expiresAt" :timestamp="license?.expiresAt" />
+                                <t v-else path="generic.never" />
                             </skeleton>
                         </td>
                     </tr>

--- a/src/views/admin/LicenseInfo.vue
+++ b/src/views/admin/LicenseInfo.vue
@@ -49,7 +49,7 @@
                             <skeleton :content="16">
                                 <t v-if="!license?.expiresAt" path="generic.never" />
 
-                                {{ license?.expiresAt }} <!-- TODO: <date :value="x" /> component? -->
+                                <date :timestamp="license?.expiresAt" />
                             </skeleton>
                         </td>
                     </tr>

--- a/src/views/admin/LicenseInfo.vue
+++ b/src/views/admin/LicenseInfo.vue
@@ -49,7 +49,7 @@
                             <skeleton :content="16">
                                 <t v-if="!license?.expiresAt" path="generic.never" />
 
-                                <date :timestamp="license?.expiresAt" />
+                                <date v-else :timestamp="license?.expiresAt" />
                             </skeleton>
                         </td>
                     </tr>


### PR DESCRIPTION
This PR includes a new Date component which shows a relative time with an absolute formatted date as a tippy.

This PR closes #133 

I have included this new Date component per the following todo. https://github.com/wisp-gg/frontend/blob/02e4ab26e9c481d5ab7f781361e653bcb315b7b1/src/views/admin/LicenseInfo.vue#L52

Date component can be used like so: `<date :timestamp=x />`

Here are screenshots demonstrating the changes and the date component.

Before:
![image](https://user-images.githubusercontent.com/34663790/154388736-806f197f-c063-49cd-bb46-806fab276816.png)

After:
![image](https://user-images.githubusercontent.com/34663790/154388855-eb8338db-78be-4a2c-90f2-ef8386e68d98.png)
