### PR TITLE
refactor: jetbrains mono for console font

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -133,6 +133,11 @@
         }
       }
     },
+    "@fontsource/jetbrains-mono": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-4.5.3.tgz",
+      "integrity": "sha512-R+dpCzt9b7O6ldKFXLvjZNQ2F+5i2/ctRgauRGvEj/3zBQVmnrjPeqPndYsZ1vz6Jg0K8TOS9JeMQavjoBHPwA=="
+    },
     "@fontsource/rubik": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/@fontsource/rubik/-/rubik-4.5.2.tgz",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "lint": "eslint --quiet --ext .js,.ts,.vue src"
   },
   "dependencies": {
+    "@fontsource/jetbrains-mono": "^4.5.3",
     "@fontsource/rubik": "^4.5.2",
     "@fortawesome/fontawesome-svg-core": "^1.2.36",
     "@fortawesome/free-brands-svg-icons": "^5.15.4",

--- a/src/views/server/Console.vue
+++ b/src/views/server/Console.vue
@@ -31,6 +31,7 @@
 
     .xterm {
         flex-grow: 1;
+        font-family: "JetBrains Mono", monospace;
     }
 
     .xterm-viewport {
@@ -100,8 +101,10 @@ export default defineComponent({
                 allowTransparency: true,
                 cursorStyle: 'underline',
                 disableStdin: true,
-                fontSize: 12,
-                fontFamily: 'monospace',
+                fontSize: 14,
+                fontFamily: 'JetBrains Mono',
+                fontWeight: 'normal',
+                lineHeight: 1.1,
                 rows: 30,
                 scrollback: 1000,
                 theme: {


### PR DESCRIPTION
Better font for the console to hopefully make it more readable.

Old Console Font:
![](https://media.discordapp.net/attachments/785652125707141160/945438061527961620/unknown.png?width=1440&height=651)

New Console Font:
![](https://i.lunaversity.dev/firefox_VPLegg2jZL.png)