### PR TITLE
Fixes padding on server card, hopefully better responsiveness too

### DIFF
--- a/src/components/List.vue
+++ b/src/components/List.vue
@@ -2,7 +2,7 @@
     <div class="w-full block">
         <slot name="layout" :results="list?.results" :pagination="list?.pagination" :search="search" :set-page="setPage">
             <slot v-if="searchable" name="search" :submit="search">
-                <div class="flex mb-4">
+                <div class="flex mb-4 items-center">
                     <!-- TODO: Spinner to appear on right side signifying it is currently searching -->
                     <input class="input w-full flex-grow" name="search" :placeholder="t('generic.search')" @keyup="search">
 

--- a/src/views/Index.vue
+++ b/src/views/Index.vue
@@ -1,7 +1,7 @@
 <template>
     <list service-id="servers@getAll" :per-page="12" searchable>
         <template #results="{ results }">
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-6" v-if="results.length > 0">
+            <div class="grid grid-cols-1 2xl:grid-cols-2 gap-x-4 gap-y-6" v-if="results.length > 0">
                 <server-card v-for="(result, idx) of results" :key="idx" :server="result" />
             </div>
             <div v-else>

--- a/src/views/ServerCard.vue
+++ b/src/views/ServerCard.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="w-full lg:even:pl-3 lg:odd:pr-3">
+    <div class="w-full 2xl:even:pl-3 2xl:odd:pr-3">
         <div class="server flex flex-col text-center overflow-hidden whitespace-nowrap" :style="`--thumbnail:url('${server?.egg?.thumbnail || minecraft}');`">
             <div class="gradient" />
             <div class="flex items-center bg-primary-900 bg-opacity-25 px-4 md:px-8 py-4">
@@ -16,7 +16,7 @@
                             <router-link :to="{name: 'server.system.index', params: { server: server?.uuidShort }}">
                                 {{ server?.name }}
                             </router-link>
-                            <span class="text-white/50 block md:inline text-sm leading-none tracking-tight pl-2" v-clipboard>
+                            <span class="text-white/50 hidden md:block md:inline text-sm leading-none tracking-tight pl-2" v-clipboard>
                                 {{ server?.uuidShort }}
                             </span>
                         </skeleton>
@@ -34,7 +34,7 @@
 
                 <button
                     v-tippy="'generic.server.go_to_console'"
-                    class="border border-primary-50 px-2 rounded text-primary-0 hover:text-white mr-4 hidden md:block"
+                    class="border border-primary-50 px-2 py-1 rounded text-primary-0 hover:text-white mr-4 hidden md:block"
                     @click="server?.openConsolePopup()"
                 >
                     <fa :icon="['fas', 'external-link-square-alt']" fixed-width />
@@ -43,7 +43,7 @@
                     <router-link :to="{name: 'server.system.index', params: { server: server?.uuidShort }}">
                         <button
                             v-tippy="'generic.server.manage'"
-                            class="border border-primary-50 px-2 rounded text-primary-0 hover:text-white hidden md:block"
+                            class="border border-primary-50 px-2 py-1 rounded text-primary-0 hover:text-white hidden md:block"
                         >
                             <fa :icon="['fas', 'wrench']" fixed-width />
                         </button>

--- a/src/views/ServerCard.vue
+++ b/src/views/ServerCard.vue
@@ -16,7 +16,7 @@
                             <router-link :to="{name: 'server.system.index', params: { server: server?.uuidShort }}">
                                 {{ server?.name }}
                             </router-link>
-                            <span class="text-white/50 hidden md:block md:inline text-sm leading-none tracking-tight pl-2" v-clipboard>
+                            <span class="text-white/50 hidden md:inline text-sm leading-none tracking-tight pl-2" v-clipboard>
                                 {{ server?.uuidShort }}
                             </span>
                         </skeleton>
@@ -34,7 +34,7 @@
 
                 <button
                     v-tippy="'generic.server.go_to_console'"
-                    class="border border-primary-50 px-2 py-1 rounded text-primary-0 hover:text-white mr-4 hidden md:block"
+                    class="border border-primary-50 px-2 rounded text-primary-0 hover:text-white mr-4 hidden md:block"
                     @click="server?.openConsolePopup()"
                 >
                     <fa :icon="['fas', 'external-link-square-alt']" fixed-width />
@@ -43,7 +43,7 @@
                     <router-link :to="{name: 'server.system.index', params: { server: server?.uuidShort }}">
                         <button
                             v-tippy="'generic.server.manage'"
-                            class="border border-primary-50 px-2 py-1 rounded text-primary-0 hover:text-white hidden md:block"
+                            class="border border-primary-50 px-2 rounded text-primary-0 hover:text-white hidden md:block"
                         >
                             <fa :icon="['fas', 'wrench']" fixed-width />
                         </button>


### PR DESCRIPTION
Apparently on laptop screens that had certain things such as a sidebar from the browser (e.g. from opera gx) breakpoints wouldn't work properly. This should hopefully fix that issue.

imo it'd just be better for laptops to see the entire card in 1 column instead of 2 to prevent any weird alignments - on desktop screens it should still display 2 columns however.

Also added a tad bit of padding to the server card icons for now but I believe there is a bigger underlying issue as these issues do not appear in local builds.

Laptop Preview (1280x800):
![](https://i.lunaversity.dev/firefox_3W2Qzw1dn3.png)