### PR TITLE
fix: increase vertical padding of select

### DIFF
--- a/src/components/forms/FormSelect.vue
+++ b/src/components/forms/FormSelect.vue
@@ -104,7 +104,7 @@
 <style src="@vueform/multiselect/themes/default.css"></style>
 <style lang="scss">
 .multiselect {
-    @apply bg-primary-400 py-4 px-5 rounded-md border-none;
+    @apply bg-primary-400 py-5 px-5 rounded-md border-none;
 
     &.is-active {
         @apply shadow-none;


### PR DESCRIPTION
This PR increases the vertical padding of the select component. In doing so it makes the select components the same height as other form components, making things look more natural.

Preview of changes:
<img width="725" alt="Screen Shot 2022-03-20 at 7 30 57 PM" src="https://user-images.githubusercontent.com/34663790/159190726-154ca355-f4a6-45a0-b53b-a63e26fb5aa5.png">

(after)
<img width="726" alt="Screen Shot 2022-03-20 at 7 30 42 PM" src="https://user-images.githubusercontent.com/34663790/159190739-0025d86a-1a5c-49cd-a6c2-c0cf3b76a165.png">

