### PR TITLE
feat: consistent timezones for schedules

### DIFF
--- a/src/views/server/schedules/ManageScheduleModal.vue
+++ b/src/views/server/schedules/ManageScheduleModal.vue
@@ -74,7 +74,9 @@ export default defineComponent({
                 // TODO: locale support
                 return {
                     description: cronstrue.toString(expression, { locale: 'en', use24HourTimeFormat: true }),
-                    nextRunTime: formatDateAbsolute(cronParser.parseExpression(expression).next().toISOString(), 'LL @ LT'),
+                    nextRunTime: formatDateAbsolute(cronParser.parseExpression(expression, {
+                        tz: 'Europe/London'
+                    }).next().toISOString(), 'LL @ LT'),
                 };
             } catch { // Invalid cron
                 return;


### PR DESCRIPTION
Fixes #233 

Adding specific timezone for `cronParses` in the Manage Schedule Modal seems to fix the issue with differing "next run" times in various places.

With this fix I was able to see the same consistent date on index, manage and modal page.