### PR TITLE
fix: multiselect tags search render glitch

### DIFF
--- a/src/assets/css/wisp.scss
+++ b/src/assets/css/wisp.scss
@@ -420,3 +420,12 @@ button {
 
   color: #fff !important;
 }
+
+/*
+TODO: Better approach? It's using 100% height as default, but parent doesn't set any.
+TODO: Margin is being calculated based on non-existing variables, setting it to 4px makes it the same as selected inputs.
+*/
+.multiselect-tags-search-wrapper {
+  margin: 4px !important;
+  height: 28px !important;
+}


### PR DESCRIPTION
Fixes #136 

For some reason there is a render glitch happening only on `production`, where the search box for multiselect tags has 1px height.
On `dev`, height is set to something around 27px.

Height of the element is by default set to `100%`, but parent element has no height set, resulting in these unexpected glitches.
Overriding this manually to 28px height and 4px margin makes it the same size as the tags.

Resizing the page seems to have no impact on the size of the box, nor the tags anyway, so hard-coding this should have no real downside.