### PR TITLE
Check that compares disk usage with disk space

### DIFF
--- a/src/plugins/upload.ts
+++ b/src/plugins/upload.ts
@@ -80,7 +80,17 @@ export async function handleUploadEvent(evt: Event, path: string) {
                 uploaded_size: 0,
             };
 
-            pendingFiles.value[identifier] = await handleWebkitEntry(webkitEntry, identifier, path, webkitEntry.name);
+            // Check if file is smaller than the available disk space on the server, and if not, show an error.
+            if (state.models.server?.node?.diskSpace < webkitEntry.size) {
+                dispatch('alerts/add', {
+                    type: 'danger',
+                    title: ['server.files.upload_too_large', { name: webkitEntry.name }],
+                });
+                return;
+            } else {
+                pendingFiles.value[identifier] = await handleWebkitEntry(webkitEntry, identifier, path, webkitEntry.name);
+            }
+
         } else {
             const actualFile: FileWithMetadata = file instanceof File ? file : file.getAsFile();
             if (!actualFile) return; // Should we throw an error instead?


### PR DESCRIPTION
This pull request should resolve #409 Where it was possible to upload a file and the front-end would not have checked if the file upload was even valid so you could upload 1tb for example and fill the server above its capacity.

The code is a basic check that checks the server limit and uploads disk usage and then either continues or gives an error.