### PR TITLE
Issue 20 - Start resource graphs from 0

### DIFF
--- a/src/components/Chart.vue
+++ b/src/components/Chart.vue
@@ -187,6 +187,7 @@ export default defineComponent({
                 },
                 yaxis: [
                     {
+                        min: 0,
                         decimalsInFloat: false,
                         labels: {
                             style: {
@@ -305,6 +306,8 @@ export default defineComponent({
             };
 
             chart.render();
+
+            addPoint(new Date().getTime(), 0);
 
             useDaemonEvent('server-proc', data => {
                 let val: number | null = null;

--- a/src/components/Chart.vue
+++ b/src/components/Chart.vue
@@ -308,7 +308,7 @@ export default defineComponent({
             chart.render();
 
             // after the chart renders, we'll initially add a point to the graph for a smoother transition
-            addPoint(new Date().getTime(), 0);
+            addPoint(Date.now(), 0);
 
             useDaemonEvent('server-proc', data => {
                 let val: number | null = null;

--- a/src/components/Chart.vue
+++ b/src/components/Chart.vue
@@ -307,6 +307,7 @@ export default defineComponent({
 
             chart.render();
 
+            // after the chart renders, we'll initially add a point to the graph for a smoother transition
             addPoint(new Date().getTime(), 0);
 
             useDaemonEvent('server-proc', data => {


### PR DESCRIPTION
This PR closes: https://github.com/wisp-gg/issue-tracker/issues/20

Graphs will now have an initial zero starting point allowing for a smoother transition into the real usage data, instead of starting from the first event we get from the daemon.