### PR TITLE
Issue 61 - Signout all sessions on password change

### DIFF
--- a/src/api/services/request.ts
+++ b/src/api/services/request.ts
@@ -110,7 +110,7 @@ export default class RequestService {
 
                 return res.data;
             })
-            .catch(err => {
+            .catch(async err =>  {
                 if (err instanceof TranslatableError) {
                     throw err;
                 }
@@ -154,7 +154,9 @@ export default class RequestService {
                         // TODO: this should be re-evaluated, if the session becomes invalid it'll be met with 401 (incl. settings endpoint => please refresh page)
                         // We can't refresh here because it'll trigger an infinite loop (unless @me endpoint gets whitelisted).
                         // Though I don't think this is really needed either.
-                        // refresh();
+                        await dispatch('user/set', undefined);
+
+                        refresh();
                         break;
                     case 403:
                         // TODO: display that no perms (although this should never realistically happen)

--- a/src/api/services/request.ts
+++ b/src/api/services/request.ts
@@ -151,9 +151,6 @@ export default class RequestService {
                         }
                         break;
                     case 401:
-                        // TODO: this should be re-evaluated, if the session becomes invalid it'll be met with 401 (incl. settings endpoint => please refresh page)
-                        // We can't refresh here because it'll trigger an infinite loop (unless @me endpoint gets whitelisted).
-                        // Though I don't think this is really needed either.
                         await dispatch('user/set', undefined);
 
                         refresh();


### PR DESCRIPTION
Closes https://github.com/wisp-gg/issue-tracker/issues/61

This PR is more of a visual / frontend only change, as when a users password is changed, any device still logged in can not perform any action, but the router still lets the user visit pages (despite not being able to take action on anything), this PR will now unset the user whenever a 401 is encountered, and then gracefully refreshes.

I'd also like to be clear that this issue was not a security issue but more of a visual issue on the frontend only, no actions can be taken when the user's session has been invalidated and this was already successfully happening on the backend.